### PR TITLE
Bug: Fix the issue with multiple bots on the same chat

### DIFF
--- a/src/main/default/classes/services/BotService.cls
+++ b/src/main/default/classes/services/BotService.cls
@@ -9,14 +9,14 @@ global abstract class BotService {
 
     /**
      * Send message to the chat
-     * @param chatId External id of the chat
+     * @param chatId External id of the chat. Can be either source chat messenger id or the formed one that is stored in Chat__c.ExternalId__c
      * @param message Message to send
      */
     global void send(String chatId, String message) {
-        String messageId = sendMessage(chatId, message);
+        String messageId = sendMessage(chatId.substringBefore(':'), message);
         ChatMessage__c messageRecord = new ChatMessage__c(
             Text__c = message,
-            Chat__r = new Chat__c(ExternalId__c = chatId),
+            Chat__r = new Chat__c(ExternalId__c = BotUtils.generateChatId(bot.TokenHash__c, chatId)),
             Bot__c = bot.id,
             ExternalId__c = messageId
         );

--- a/src/main/default/classes/trigger-handlers/BotUpdateHandler.cls
+++ b/src/main/default/classes/trigger-handlers/BotUpdateHandler.cls
@@ -5,6 +5,7 @@ public class BotUpdateHandler implements Triggers.IHandler {
         this(new BotServiceFactory());
     }
 
+    @TestVisible
     private BotUpdateHandler(BotServiceFactory serviceFactory) {
         this.serviceFactory = serviceFactory;
     }
@@ -49,7 +50,11 @@ public class BotUpdateHandler implements Triggers.IHandler {
         } else if (String.isNotBlank(chat.firstName) || String.isNotBlank(chat.lastName)) {
             chatName = getValueOrEmptyString(chat.firstName) + ' ' + getValueOrEmptyString(chat.lastName);
         }
-        return new Chat__c(Name = chatName.trim(), Bot__c = bot.Id, ExternalId__c = String.valueOf(chat.id));
+        return new Chat__c(
+            Name = chatName.trim(),
+            Bot__c = bot.Id,
+            ExternalId__c = BotUtils.generateChatId(bot.TokenHash__c, String.valueOf(chat.id))
+        );
     }
 
     private ChatUser__c getChatUser(BotUpdateModel.UserModel user) {

--- a/src/main/default/classes/utils/BotUtils.cls
+++ b/src/main/default/classes/utils/BotUtils.cls
@@ -38,4 +38,11 @@ public class BotUtils {
             new BotUpsertDataEvent__e(Data__c = JSON.serialize(records), ExternalIdField__c = externalIdField)
         );
     }
+
+    public static String generateChatId(String botTokenHash, String chatExternalId) {
+        if (chatExternalId.contains(':')) {
+            return chatExternalId;
+        }
+        return chatExternalId + ':' + botTokenHash.substring(0, 20);
+    }
 }

--- a/src/main/default/objects/Chat__c/fields/ExternalId__c.field-meta.xml
+++ b/src/main/default/objects/Chat__c/fields/ExternalId__c.field-meta.xml
@@ -2,10 +2,10 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>ExternalId__c</fullName>
     <caseSensitive>false</caseSensitive>
-    <description>Chat id that is shared by a messenger</description>
+    <description>Chat id that is shared by a messenger concatenated with the first 20 bot token hash characters</description>
     <externalId>true</externalId>
     <label>External Id</label>
-    <length>20</length>
+    <length>40</length>
     <required>true</required>
     <trackTrending>false</trackTrending>
     <type>Text</type>

--- a/src/test/classes/BotContextTest.cls
+++ b/src/test/classes/BotContextTest.cls
@@ -80,7 +80,7 @@ private class BotContextTest {
     }
 
     private static BotContext createBotContext() {
-        Bot__c bot = [SELECT Type__c, Handler__c FROM Bot__c LIMIT 1];
+        Bot__c bot = [SELECT Type__c, Handler__c, TokenHash__c FROM Bot__c LIMIT 1];
         return new BotContext(
             bot,
             BotUpdateModel.fromPayload(createTelegramUpdateJson(), BOT_TYPE),

--- a/src/test/classes/BotServiceTest.cls
+++ b/src/test/classes/BotServiceTest.cls
@@ -18,8 +18,12 @@ public class BotServiceTest {
 
     @IsTest
     private static void send_telegramSendMessage_shouldSendAndCreateMessageRecord() {
-        Bot__c bot = [SELECT Type__c, Handler__c, Token__c FROM Bot__c LIMIT 1];
-        Chat__c chat = new Chat__c(Name = 'Test', Bot__c = bot.Id, ExternalId__c = '3214');
+        Bot__c bot = [SELECT Type__c, Handler__c, Token__c, TokenHash__c FROM Bot__c LIMIT 1];
+        Chat__c chat = new Chat__c(
+            Name = 'Test',
+            Bot__c = bot.Id,
+            ExternalId__c = '3214:' + bot.TokenHash__c.substring(0, 20)
+        );
         insert chat;
         BotService service = new TelegramBotService(bot);
         Test.setMock(HttpCalloutMock.class, new BotWebhookCalloutMock(BOT_TYPE, TelegramBotMethod.SendMessage.name()));

--- a/src/test/classes/BotUpdateEventTriggerTest.cls
+++ b/src/test/classes/BotUpdateEventTriggerTest.cls
@@ -45,7 +45,7 @@ private class BotUpdateEventTriggerTest {
                 'text' => 'Hello world!'
             }
         };
-        Bot__c bot = [SELECT Type__c, Handler__c FROM Bot__c LIMIT 1];
+        Bot__c bot = [SELECT Type__c, Handler__c, TokenHash__c FROM Bot__c LIMIT 1];
         Test.startTest();
         Eventbus.publish(new BotUpdateEvent__e(Bot__c = JSON.serialize(bot), Payload__c = JSON.serialize(payload)));
         Test.getEventBus().deliver();
@@ -63,14 +63,14 @@ private class BotUpdateEventTriggerTest {
         System.assertEquals(1, chats.size());
         System.assertEquals('matsuev', chats.get(0).Name);
         System.assertEquals(bot.Id, chats.get(0).Bot__c);
-        System.assertEquals('876541222', chats.get(0).ExternalId__c);
+        System.assertEquals('876541222:' + bot.TokenHash__c.substring(0, 20), chats.get(0).ExternalId__c);
         // User
         System.assertEquals(1, users.size());
         System.assertEquals('matsuev', users.get(0).Name);
         System.assertEquals(null, users.get(0).FirstName__c);
         System.assertEquals('matsuev', users.get(0).LastName__c);
         System.assertEquals('ilya.matsuev', users.get(0).Username__c);
-        System.assertEquals('876541222', chats.get(0).ExternalId__c);
+        System.assertEquals('876541222', users.get(0).ExternalId__c);
         // Message
         System.assertEquals(1, messages.size());
         System.assertEquals('Hello world!', messages.get(0).Text__c);


### PR DESCRIPTION
### What does this PR do?

Fixes the issue of having a single chat for multiple bots

## The PR fulfills these requirements:

[x] Tests for the proposed changes have been added/updated.  
[x] Code linting and formatting were performed.

### Functionality Before

Overrides a single chat record for both bots

### Functionality After

The chat is generated with the unique key as {chatExernalId} + ':' + {botTokenHash.substr(0, 20)}
